### PR TITLE
Fix invalid HTML in sample page

### DIFF
--- a/examples/doc_root/index.html
+++ b/examples/doc_root/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
-  <header>
+  <head>
     <title>Welcome to H2O</title>
-  </header>
+  </head>
   <body>
     <p>Welcome to H2O - an optimized HTTP server</p>
     <p>It works!</p>


### PR DESCRIPTION
The current sample page was not valid HTML since it was using `<header>` instead of `<head>` tag.

Not a huge deal, but for the sample page of a standards compliant web server, this seemed like it shouldn't be overlooked! :smile: 
